### PR TITLE
Fix UpdateCmdKeys iterating over keybind array indices instead of values

### DIFF
--- a/web/static/webclient/js/webclient.js
+++ b/web/static/webclient/js/webclient.js
@@ -3,7 +3,7 @@ const input_box = document.getElementById("input_box");
 const game_out = document.getElementById("_log");
 // the full suite i think will require a different solution for getting the element, since i don't know if these characters are valid in element IDs
 // const keybind_labels = [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '+', 'Enter', '.', '-', '*', '/' ];
- const keybind_labels = [ '1', '2', '3', '4', '5', '6', '7', '8', '9' ];
+const keybind_labels = [ '1', '2', '3', '4', '5', '6', '7', '8', '9' ];
 
 // websocket info
 const wsstring = wsurl +"?"+ csessid;
@@ -228,7 +228,7 @@ function LogSessionCmd(store_key, message) {
 // function to load commands to numpad bindings
 function UpdateCmdKeys(bindings) {
 	// walk through all of the keys and update
-	for (key in keybind_labels) {
+	for (const key of keybind_labels) {
 		key_el = document.getElementById("keybind_"+key);
 		if (!key_el) continue;
 		if (bindings[key]) {


### PR DESCRIPTION
## Commit Description

This commit changes the main loop in `UpdateCmdKeys` to a `for...of` loop instead of a `for...in` loop.

Because the `for...in` loop iterates over array indices instead of values, no binding can be assigned to Numpad 9 (verified using console.log).

After making this change locally I was able to assign bindings to Numpad 9.